### PR TITLE
Change DRIP_TIMEOUT to DRIP_SHUTDOWN in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ time limit defaults to four hours, but you can change this by setting the
 `DRIP_SHUTDOWN` environment variable before calling `drip` to set a timeout, in
 minutes:
 
-    DRIP_TIMEOUT=30 drip -cp clojure.jar clojure.main
+    DRIP_SHUTDOWN=30 drip -cp clojure.jar clojure.main
 
 This creates a Clojure repl as usual, either by starting up a new one or
 connecting to a waiting JVM. But the JVM that is spun up to serve future


### PR DESCRIPTION
Code example doesn't match text block. Checked in Main.java that it's SHUTDOWN that's being used.
