### PR TITLE
Fix C99-related compilation errors.

### DIFF
--- a/src/drip_daemon.c
+++ b/src/drip_daemon.c
@@ -52,7 +52,8 @@ int main(int argc, char **argv) {
       spit_int("status", status);
     } else {
       fprintf(stderr, "java process exited prematurely with status %d: ", status);
-      for (int i=1; i < argc; i++) {
+      int i;
+      for (i=1; i < argc; i++) {
         fprintf(stderr, "%s ", argv[i]);
       }
       fprintf(stderr, "\n");


### PR DESCRIPTION
Fixed by fixing C-file syntax instead of fixing compiler options, since merely adding new compiler
options fixes the build, but produces new warnings.
