### PR TITLE
Honor the user set umask value

### DIFF
--- a/src/drip_daemon.c
+++ b/src/drip_daemon.c
@@ -35,8 +35,6 @@ int main(int argc, char **argv) {
   // Start a child process and exit the parent.
   if (check("fork parent", fork()) != 0) exit(0);
 
-  umask(0);
-
   int child = check("fork child", fork());
   if (child == 0) {
     check("setsid", setsid());


### PR DESCRIPTION
drip should respect the umask set in the environment especially so that it
doesn't inadvertently create world writable files/directories.
