### PR TITLE
Use JRuby's DripMain plus a better init for booting JRuby.

### DIFF
--- a/bin/drip
+++ b/bin/drip
@@ -160,8 +160,8 @@ function default_init {
             DRIP_INIT_CLASS='clojure.main'
             DRIP_INIT=$(printf $f '-e' 'nil');;
         org.jruby.Main)
-            DRIP_INIT_CLASS='org.jruby.main'
-            DRIP_INIT=$(printf $f '-e' 'nil');;
+            DRIP_INIT_CLASS='org.jruby.main.DripMain'
+            DRIP_INIT=$(printf $f '1 + 1');;
         scala.tools.nsc.MainGenericRunner)
             DRIP_INIT_CLASS='scala.tools.nsc.MainGenericRunner'
             DRIP_INIT=$(printf $f '-e' 'null');;


### PR DESCRIPTION
This commit changes two things when Drip is used to run JRuby:
- DRIP_INIT_CLASS now uses org.jruby.main.DripMain

DripMain has been available in JRuby since 1.7.0 was released over
a year ago, and does extra prebooting to prepare a JRuby instance
and to optionally load dripmain.rb in the current directory. With
these combined changes, JRuby commands can be reduced from seconds
to tenths of a second, even for complex commands that must boot
frameworks like Raile.
- DRIP_INIT provides more useful code for warming the instance.

Rather than simple evaluating "nil", we instead use "1 + 1" which
forces more classes to boot and dynamic call mechanisms to fire.
The DRIP_INIT arguments are not used in currently-released
versions of JRuby, but currently-released versions of JRuby use
the "1 + 1" boot by default.

It is my understanding that if org.jruby.main.DripMain is not
present, the default behavior is falling back on Drip's own main,
so at worst this will have no impact on older versions of JRuby
used with Drip. It's also worth pointing out that the old class --
org.jruby.main -- does not exist, so current versions of Drip were
not actually prebooting JRuby at all. The correct class would have
been org.jruby.Main.
