### PR TITLE
Don't require empty DRIP_INIT just to use DRIP_INIT_CLASS

### DIFF
--- a/src/org/flatland/drip/Main.java
+++ b/src/org/flatland/drip/Main.java
@@ -70,9 +70,8 @@ public class Main {
     Method main = mainMethod(mainClass);    
     Method init = mainMethod(System.getenv("DRIP_INIT_CLASS"));
     String initArgs = System.getenv("DRIP_INIT");
-    if (initArgs != null) {
-      invoke(init == null ? main : init, split(initArgs, "\n"));
-    }
+    initArgs = initArgs == null ? "" : initArgs;
+    invoke(init == null ? main : init, split(initArgs, "\n"));
     startIdleKiller();
 
     Scanner fromBash = new Scanner(new File(dir, "control"));


### PR DESCRIPTION
This commit defaults the value of DRIP_INIT to an empty string in the event the environment variable isn't set. This removes the stumbling block of having to set an empty DRIP_INIT environment variable just to get Drip to respect the DRIP_INIT_CLASS environment variable.

This could also be done in the drip shell script but this seemed like a better place to put it.
