### PR TITLE
Correctly provide default value for DRIP_POOL

### DIFF
--- a/bin/drip
+++ b/bin/drip
@@ -345,7 +345,7 @@ function run_drip_command {
 # Let's go.
 
 DRIP_VERSION=0.2.5
-DRIP_POOL=${DRIP_POOL:1}
+DRIP_POOL=${DRIP_POOL:-1}
 DRIP_HOME=${DRIP_HOME:-~/.drip}
 DRIP_BRANCH=${DRIP_BRANCH:-master}
 DRIP_REPO=${DRIP_REPO:-http://clojars.org/repo}


### PR DESCRIPTION
This syntax matches all other default values.  Previously this failed
with:

/home/gaul/bin/drip: line 223: ((: 0 <  : syntax error: operand expected (error token is "<  ")
