### PR TITLE
The 'install' target should depend on 'compile'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ clean:
 	rm -f ${binaries}
 	rm -f ${jar}
 
-install: jar
+install: jar compile
 	mkdir -p ${prefix}
 	ln -sf $$PWD/bin/drip ${prefix}/drip
 


### PR DESCRIPTION
Without invoking both `jar` and `compile` an invocation of "make install" will result in a non-functional drip installation since `drip_daemon` and `drip_proxy` won't be built.
