### PR TITLE
Fix warning: implicit declaration of function ‘wait’

### DIFF
--- a/src/drip_daemon.c
+++ b/src/drip_daemon.c
@@ -5,6 +5,7 @@
 #include <stdio.h>
 #include <unistd.h>
 #include <sys/stat.h>
+#include <sys/wait.h>
 
 static char* jvm_dir;
 


### PR DESCRIPTION
Fixes the following compiler warning:
```
.../src/drip_daemon.c: In function ‘main’:                         
.../src/drip_daemon.c:46:5: warning: implicit declaration of function ‘wait’ [-Wimplicit-function-declaration]                                                
     wait(&status);                                                                        
     ^~~~
```