### PR TITLE
Upgrading for clean compilation with openjdk-10

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ c_src=$(wildcard src/*.c)
 classes=$(subst src,classes,$(java_src:.java=.class))
 binaries=$(subst src,bin,$(c_src:.c=))
 jar=drip.jar
-javac=javac -source 1.5 -target 1.5
+javac=javac
 
 all: compile jar
 

--- a/src/drip_daemon.c
+++ b/src/drip_daemon.c
@@ -5,6 +5,8 @@
 #include <stdio.h>
 #include <unistd.h>
 #include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/wait.h>
 
 static char* jvm_dir;
 


### PR DESCRIPTION
When building using make, I had the following errors:

```
javac -source 1.5 -target 1.5 src/org/flatland/drip/Main.java src/org/flatland/drip/Switchable.java src/org/flatland/drip/SwitchableInputStream.java src/org/flatland/drip/SwitchableOutputStream.java -d classes/
warning: [options] bootstrap class path not set in conjunction with -source 5
error: Source option 5 is no longer supported. Use 6 or later.
error: Target option 1.5 is no longer supported. Use 1.6 or later.
make: *** [Makefile:13: classes/org/flatland/drip/Main.class] Error 2
```
If I replace them with 1.6, I got:
```
warning: [options] bootstrap class path not set in conjunction with -source 6
warning: [options] source value 6 is obsolete and will be removed in a future release
warning: [options] target value 1.6 is obsolete and will be removed in a future release
warning: [options] To suppress warnings about obsolete options, use -Xlint:-options.
```
But we don't need them anymore AFAIK.
So I just dropped the options.
Then another warning came up:

```
src/drip_daemon.c:46:5: warning: implicit declaration of function ‘wait’ [-Wimplicit-function-declaration]
```
So I fixed that one according to 
https://stackoverflow.com/questions/41884685/implicit-declaration-of-function-wait

Thank you devs !